### PR TITLE
Fix format validators null-safety, improve composition exception messages, fix formatProvidedValue object leak

### DIFF
--- a/src/Exception/ComposedValue/AllOfException.php
+++ b/src/Exception/ComposedValue/AllOfException.php
@@ -12,4 +12,5 @@ namespace PHPModelGenerator\Exception\ComposedValue;
 class AllOfException extends InvalidComposedValueException
 {
     protected const COMPOSED_ERROR_MESSAGE = 'Requires to match all composition elements but matched %s elements.';
+    protected const COMPOSED_KEYWORD = 'allOf';
 }

--- a/src/Exception/ComposedValue/AnyOfException.php
+++ b/src/Exception/ComposedValue/AnyOfException.php
@@ -12,4 +12,5 @@ namespace PHPModelGenerator\Exception\ComposedValue;
 class AnyOfException extends InvalidComposedValueException
 {
     protected const COMPOSED_ERROR_MESSAGE = 'Requires to match at least one composition element.';
+    protected const COMPOSED_KEYWORD = 'anyOf';
 }

--- a/src/Exception/ComposedValue/InvalidComposedValueException.php
+++ b/src/Exception/ComposedValue/InvalidComposedValueException.php
@@ -30,7 +30,7 @@ abstract class InvalidComposedValueException extends ValidationException
         $this->branchDescriptions = $branchDescriptions;
         $this->discriminatorInfo = $discriminatorInfo;
 
-        parent::__construct($this->buildMessage($propertyName), $propertyName, $providedValue);
+        parent::__construct($this->buildMessage($propertyName, $providedValue), $propertyName, $providedValue);
     }
 
     public function getSucceededCompositionElements(): int
@@ -53,137 +53,35 @@ abstract class InvalidComposedValueException extends ValidationException
         return $this->discriminatorInfo;
     }
 
-    private function buildMessage(string $propertyName): string
+    private function buildMessage(string $propertyName, $providedValue): string
     {
-        $totalBranches = $this->branchDescriptions !== []
-            ? count($this->branchDescriptions)
-            : count($this->compositionErrorCollection);
-        $succeeded = $this->succeededCompositionElements;
-        $keyword = static::COMPOSED_KEYWORD ?: 'composition';
-        $header = $this->buildHeader($propertyName, $succeeded, $totalBranches, $keyword);
+        $compositionIndex = 0;
 
-        $hasDetailedErrors = $this->compositionErrorCollection !== [];
+        return "Invalid value for $propertyName declined by composition constraint.\n  " .
+            sprintf(static::COMPOSED_ERROR_MESSAGE, $this->succeededCompositionElements) .
+            array_reduce(
+                $this->compositionErrorCollection,
+                function (string $carry, ErrorRegistryExceptionInterface $exception) use (&$compositionIndex): string {
+                    $index = ++$compositionIndex;
+                    $description = $this->branchDescriptions[$index - 1] ?? '';
 
-        if ($hasDetailedErrors) {
-            $matchedLines = [];
-            $failedLines = [];
+                    $line = "  - Composition element #$index";
+                    if ($description !== '') {
+                        $line .= " ($description)";
+                    }
 
-            $branchCount = count($this->compositionErrorCollection);
-
-            for ($i = 0; $i < $branchCount; $i++) {
-                $branchNum = $i + 1;
-                $description = $this->branchDescriptions[$i] ?? '';
-
-                $line = "  #$branchNum";
-                if ($description !== '') {
-                    $line .= " ($description)";
-                }
-
-                $errors = $this->compositionErrorCollection[$i]->getErrors();
-                if ($errors !== []) {
-                    $errorTexts = array_map(
-                        static fn (ValidationException $e): string => $e->getMessage(),
-                        $errors,
-                    );
-                    $line .= ": Failed\n    * " . implode("\n    * ", $errorTexts);
-                    $failedLines[] = $line;
-                } else {
-                    $line .= ': Valid';
-                    $matchedLines[] = $line;
-                }
-            }
-
-            $sections = [];
-
-            if ($this->isAllFailedCase($succeeded, $totalBranches)) {
-                $sections[] = "  [ALL BRANCHES FAILED]\n" . implode("\n", $failedLines);
-            } else {
-                if ($matchedLines !== []) {
-                    $matchLabel = $this->getMatchLabel($succeeded, $totalBranches);
-                    $sections[] = "  $matchLabel\n" . implode("\n", $matchedLines);
-                }
-
-                if ($failedLines !== []) {
-                    $sections[] = "  [FAILED]\n" . implode("\n", $failedLines);
-                }
-            }
-
-            if ($sections !== []) {
-                $header .= "\n" . implode("\n\n", $sections);
-            }
-        }
-
-        $header .= "\n\n  Provided value: " . $this->formatProvidedValue($this->providedValue);
-
-        return $header;
-    }
-
-    private function buildHeader(string $propertyName, int $succeeded, int $total, string $keyword): string
-    {
-        $base = "Invalid value for '$propertyName'. Must match ";
-
-        if (static::COMPOSED_ERROR_MESSAGE === 'Requires to match all composition elements but matched %s elements.') {
-            return $base . "all $total ${keyword} branches, but only $succeeded matched.";
-        }
-
-        if (static::COMPOSED_ERROR_MESSAGE === 'Requires to match at least one composition element.') {
-            return $base . "at least 1 of $total ${keyword} branches, but 0 matched.";
-        }
-
-        if (static::COMPOSED_ERROR_MESSAGE === 'Requires to match one composition element but matched %s elements.') {
-            $discriminatorHint = '';
-            if (
-                $this->discriminatorInfo !== []
-                && isset($this->discriminatorInfo['propertyName'])
-                && isset($this->discriminatorInfo['mapping'])
-            ) {
-                $discriminatorHint = $this->buildDiscriminatorHint();
-            }
-
-            if ($succeeded === 0) {
-                $msg = "exactly 1 of $total ${keyword} branches, but 0 matched.";
-                return $discriminatorHint !== ''
-                    ? "$base$msg\n\n  $discriminatorHint"
-                    : "$base$msg";
-            }
-
-            $msg = "exactly 1 of $total ${keyword} branches, but $succeeded matched.";
-            return $discriminatorHint !== ''
-                ? "$base$msg\n\n  $discriminatorHint"
-                : "$base$msg";
-        }
-
-        if (static::COMPOSED_ERROR_MESSAGE === 'Requires to match none composition element but matched %s elements.') {
-            return $base . "none of the $total ${keyword} branches, but $succeeded matched.";
-        }
-
-        return $base . sprintf(static::COMPOSED_ERROR_MESSAGE, $succeeded);
-    }
-
-    private function isAllFailedCase(int $succeeded, int $total): bool
-    {
-        return $succeeded === 0 && $total > 0;
-    }
-
-    private function getMatchLabel(int $succeeded, int $total): string
-    {
-        $isOneOf = static::COMPOSED_ERROR_MESSAGE === 'Requires to match one composition element but matched %s elements.';
-
-        if ($isOneOf && $succeeded > 1) {
-            return "[MATCHED - $succeeded branches match, only 1 should]";
-        }
-
-        return '[MATCHED]';
-    }
-
-    private function buildDiscriminatorHint(): string
-    {
-        $propName = $this->discriminatorInfo['propertyName'];
-        $mapping = $this->discriminatorInfo['mapping'];
-        $validValues = array_keys($mapping);
-        $validValuesStr = implode("', '", $validValues);
-
-        return "  Discriminator: property '$propName' determines which branch applies.\n  Expected '$propName' to be one of: '$validValuesStr'.";
+                    return "$carry\n$line" . (
+                        $exception->getErrors()
+                            ? ": Failed\n    * " .
+                                implode(
+                                    "\n    * ",
+                                    array_map(fn(ValidationException $exception): string => $exception->getMessage(), $exception->getErrors())
+                                )
+                            : ': Valid'
+                        );
+                },
+                ''
+            );
     }
 
     private function formatProvidedValue($value): string

--- a/src/Exception/ComposedValue/InvalidComposedValueException.php
+++ b/src/Exception/ComposedValue/InvalidComposedValueException.php
@@ -30,7 +30,7 @@ abstract class InvalidComposedValueException extends ValidationException
         $this->branchDescriptions = $branchDescriptions;
         $this->discriminatorInfo = $discriminatorInfo;
 
-        parent::__construct($this->buildMessage($propertyName, $providedValue), $propertyName, $providedValue);
+        parent::__construct($this->buildMessage($propertyName), $propertyName, $providedValue);
     }
 
     public function getSucceededCompositionElements(): int
@@ -53,7 +53,7 @@ abstract class InvalidComposedValueException extends ValidationException
         return $this->discriminatorInfo;
     }
 
-    private function buildMessage(string $propertyName, $providedValue): string
+    private function buildMessage(string $propertyName): string
     {
         $compositionIndex = 0;
 
@@ -82,51 +82,5 @@ abstract class InvalidComposedValueException extends ValidationException
                 },
                 ''
             );
-    }
-
-    private function formatProvidedValue($value): string
-    {
-        if ($value === null) {
-            return 'null';
-        }
-
-        if (is_bool($value)) {
-            return $value ? 'true' : 'false';
-        }
-
-        if (is_string($value)) {
-            $truncated = mb_strlen($value) > 80 ? mb_substr($value, 0, 77) . '...' : $value;
-            return "'$truncated'";
-        }
-
-        if (is_int($value) || is_float($value)) {
-            return (string) $value;
-        }
-
-        if (is_array($value)) {
-            return $this->formatArrayValue($value);
-        }
-
-        if (is_object($value)) {
-            $className = get_class($value);
-            $shortName = substr($className, strrpos($className, '\\') !== false ? strrpos($className, '\\') + 1 : 0);
-            return "object($shortName)";
-        }
-
-        return (string) $value;
-    }
-
-    private function formatArrayValue(array $value): string
-    {
-        $keys = array_keys($value);
-        $keyList = array_map(
-            static fn ($k): string => is_string($k) ? "'$k'" : (string) $k,
-            $keys,
-        );
-        $list = implode(', ', array_slice($keyList, 0, 10));
-        if (count($keys) > 10) {
-            $list .= ', ...';
-        }
-        return 'array keys: [' . $list . ']';
     }
 }

--- a/src/Exception/ComposedValue/InvalidComposedValueException.php
+++ b/src/Exception/ComposedValue/InvalidComposedValueException.php
@@ -7,27 +7,30 @@ namespace PHPModelGenerator\Exception\ComposedValue;
 use PHPModelGenerator\Exception\ErrorRegistryExceptionInterface;
 use PHPModelGenerator\Exception\ValidationException;
 
-/**
- * Class InvalidComposedValueException
- *
- * @package PHPModelGenerator\Exception\ComposedValue
- */
 abstract class InvalidComposedValueException extends ValidationException
 {
     protected const COMPOSED_ERROR_MESSAGE = '';
-    /**
-     * InvalidComposedValueException constructor.
-     *
-     * @param $providedValue
-     * @param ValidationException[][] $compositionErrorCollection
-     */
+    protected const COMPOSED_KEYWORD = '';
+
+    protected int $succeededCompositionElements;
+    protected array $compositionErrorCollection;
+    protected array $branchDescriptions;
+    protected array $discriminatorInfo;
+
     public function __construct(
         $providedValue,
         string $propertyName,
-        protected int $succeededCompositionElements,
-        protected array $compositionErrorCollection
+        int $succeededCompositionElements,
+        array $compositionErrorCollection,
+        array $branchDescriptions = [],
+        array $discriminatorInfo = [],
     ) {
-        parent::__construct($this->getErrorMessage($propertyName), $propertyName, $providedValue);
+        $this->succeededCompositionElements = $succeededCompositionElements;
+        $this->compositionErrorCollection = $compositionErrorCollection;
+        $this->branchDescriptions = $branchDescriptions;
+        $this->discriminatorInfo = $discriminatorInfo;
+
+        parent::__construct($this->buildMessage($propertyName), $propertyName, $providedValue);
     }
 
     public function getSucceededCompositionElements(): int
@@ -35,34 +38,197 @@ abstract class InvalidComposedValueException extends ValidationException
         return $this->succeededCompositionElements;
     }
 
-    /**
-     * @return ValidationException[][]
-     */
     public function getCompositionErrorCollection(): array
     {
         return $this->compositionErrorCollection;
     }
 
-    protected function getErrorMessage(string $propertyName): string
+    public function getBranchDescriptions(): array
     {
-        $compositionIndex = 0;
+        return $this->branchDescriptions;
+    }
 
-        return "Invalid value for $propertyName declined by composition constraint.\n  " .
-            sprintf(static::COMPOSED_ERROR_MESSAGE, $this->succeededCompositionElements) .
-            array_reduce(
-                $this->compositionErrorCollection,
-                function (string $carry, ErrorRegistryExceptionInterface $exception) use (&$compositionIndex): string {
-                    return "$carry\n  - Composition element #" . ++$compositionIndex . (
-                        $exception->getErrors()
-                            ? ": Failed\n    * " .
-                                implode(
-                                    "\n    * ",
-                                    array_map(fn(ValidationException $exception): string => $exception->getMessage(), $exception->getErrors())
-                                )
-                            : ': Valid'
-                        );
-                },
-                ''
-            );
+    public function getDiscriminatorInfo(): array
+    {
+        return $this->discriminatorInfo;
+    }
+
+    private function buildMessage(string $propertyName): string
+    {
+        $totalBranches = $this->branchDescriptions !== []
+            ? count($this->branchDescriptions)
+            : count($this->compositionErrorCollection);
+        $succeeded = $this->succeededCompositionElements;
+        $keyword = static::COMPOSED_KEYWORD ?: 'composition';
+        $header = $this->buildHeader($propertyName, $succeeded, $totalBranches, $keyword);
+
+        $hasDetailedErrors = $this->compositionErrorCollection !== [];
+
+        if ($hasDetailedErrors) {
+            $matchedLines = [];
+            $failedLines = [];
+
+            $branchCount = count($this->compositionErrorCollection);
+
+            for ($i = 0; $i < $branchCount; $i++) {
+                $branchNum = $i + 1;
+                $description = $this->branchDescriptions[$i] ?? '';
+
+                $line = "  #$branchNum";
+                if ($description !== '') {
+                    $line .= " ($description)";
+                }
+
+                $errors = $this->compositionErrorCollection[$i]->getErrors();
+                if ($errors !== []) {
+                    $errorTexts = array_map(
+                        static fn (ValidationException $e): string => $e->getMessage(),
+                        $errors,
+                    );
+                    $line .= ": Failed\n    * " . implode("\n    * ", $errorTexts);
+                    $failedLines[] = $line;
+                } else {
+                    $line .= ': Valid';
+                    $matchedLines[] = $line;
+                }
+            }
+
+            $sections = [];
+
+            if ($this->isAllFailedCase($succeeded, $totalBranches)) {
+                $sections[] = "  [ALL BRANCHES FAILED]\n" . implode("\n", $failedLines);
+            } else {
+                if ($matchedLines !== []) {
+                    $matchLabel = $this->getMatchLabel($succeeded, $totalBranches);
+                    $sections[] = "  $matchLabel\n" . implode("\n", $matchedLines);
+                }
+
+                if ($failedLines !== []) {
+                    $sections[] = "  [FAILED]\n" . implode("\n", $failedLines);
+                }
+            }
+
+            if ($sections !== []) {
+                $header .= "\n" . implode("\n\n", $sections);
+            }
+        }
+
+        $header .= "\n\n  Provided value: " . $this->formatProvidedValue($this->providedValue);
+
+        return $header;
+    }
+
+    private function buildHeader(string $propertyName, int $succeeded, int $total, string $keyword): string
+    {
+        $base = "Invalid value for '$propertyName'. Must match ";
+
+        if (static::COMPOSED_ERROR_MESSAGE === 'Requires to match all composition elements but matched %s elements.') {
+            return $base . "all $total ${keyword} branches, but only $succeeded matched.";
+        }
+
+        if (static::COMPOSED_ERROR_MESSAGE === 'Requires to match at least one composition element.') {
+            return $base . "at least 1 of $total ${keyword} branches, but 0 matched.";
+        }
+
+        if (static::COMPOSED_ERROR_MESSAGE === 'Requires to match one composition element but matched %s elements.') {
+            $discriminatorHint = '';
+            if (
+                $this->discriminatorInfo !== []
+                && isset($this->discriminatorInfo['propertyName'])
+                && isset($this->discriminatorInfo['mapping'])
+            ) {
+                $discriminatorHint = $this->buildDiscriminatorHint();
+            }
+
+            if ($succeeded === 0) {
+                $msg = "exactly 1 of $total ${keyword} branches, but 0 matched.";
+                return $discriminatorHint !== ''
+                    ? "$base$msg\n\n  $discriminatorHint"
+                    : "$base$msg";
+            }
+
+            $msg = "exactly 1 of $total ${keyword} branches, but $succeeded matched.";
+            return $discriminatorHint !== ''
+                ? "$base$msg\n\n  $discriminatorHint"
+                : "$base$msg";
+        }
+
+        if (static::COMPOSED_ERROR_MESSAGE === 'Requires to match none composition element but matched %s elements.') {
+            return $base . "none of the $total ${keyword} branches, but $succeeded matched.";
+        }
+
+        return $base . sprintf(static::COMPOSED_ERROR_MESSAGE, $succeeded);
+    }
+
+    private function isAllFailedCase(int $succeeded, int $total): bool
+    {
+        return $succeeded === 0 && $total > 0;
+    }
+
+    private function getMatchLabel(int $succeeded, int $total): string
+    {
+        $isOneOf = static::COMPOSED_ERROR_MESSAGE === 'Requires to match one composition element but matched %s elements.';
+
+        if ($isOneOf && $succeeded > 1) {
+            return "[MATCHED - $succeeded branches match, only 1 should]";
+        }
+
+        return '[MATCHED]';
+    }
+
+    private function buildDiscriminatorHint(): string
+    {
+        $propName = $this->discriminatorInfo['propertyName'];
+        $mapping = $this->discriminatorInfo['mapping'];
+        $validValues = array_keys($mapping);
+        $validValuesStr = implode("', '", $validValues);
+
+        return "  Discriminator: property '$propName' determines which branch applies.\n  Expected '$propName' to be one of: '$validValuesStr'.";
+    }
+
+    private function formatProvidedValue($value): string
+    {
+        if ($value === null) {
+            return 'null';
+        }
+
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+
+        if (is_string($value)) {
+            $truncated = mb_strlen($value) > 80 ? mb_substr($value, 0, 77) . '...' : $value;
+            return "'$truncated'";
+        }
+
+        if (is_int($value) || is_float($value)) {
+            return (string) $value;
+        }
+
+        if (is_array($value)) {
+            return $this->formatArrayValue($value);
+        }
+
+        if (is_object($value)) {
+            $className = get_class($value);
+            $shortName = substr($className, strrpos($className, '\\') !== false ? strrpos($className, '\\') + 1 : 0);
+            return "object($shortName)";
+        }
+
+        return (string) $value;
+    }
+
+    private function formatArrayValue(array $value): string
+    {
+        $keys = array_keys($value);
+        $keyList = array_map(
+            static fn ($k): string => is_string($k) ? "'$k'" : (string) $k,
+            $keys,
+        );
+        $list = implode(', ', array_slice($keyList, 0, 10));
+        if (count($keys) > 10) {
+            $list .= ', ...';
+        }
+        return 'array keys: [' . $list . ']';
     }
 }

--- a/src/Exception/ComposedValue/NotException.php
+++ b/src/Exception/ComposedValue/NotException.php
@@ -12,4 +12,5 @@ namespace PHPModelGenerator\Exception\ComposedValue;
 class NotException extends InvalidComposedValueException
 {
     protected const COMPOSED_ERROR_MESSAGE = 'Requires to match none composition element but matched %s elements.';
+    protected const COMPOSED_KEYWORD = 'not';
 }

--- a/src/Exception/ComposedValue/OneOfException.php
+++ b/src/Exception/ComposedValue/OneOfException.php
@@ -12,4 +12,5 @@ namespace PHPModelGenerator\Exception\ComposedValue;
 class OneOfException extends InvalidComposedValueException
 {
     protected const COMPOSED_ERROR_MESSAGE = 'Requires to match one composition element but matched %s elements.';
+    protected const COMPOSED_KEYWORD = 'oneOf';
 }

--- a/src/Format/FormatValidatorFromRegEx.php
+++ b/src/Format/FormatValidatorFromRegEx.php
@@ -20,8 +20,12 @@ class FormatValidatorFromRegEx implements FormatValidatorInterface
         return $this->pattern;
     }
 
-    public static function validate(string $input, string $pattern = ''): bool
+    public static function validate(?string $input, string $pattern = ''): bool
     {
+        if ($input === null) {
+            return true;
+        }
+
         return preg_match($pattern, $input) === 1;
     }
 }

--- a/src/Format/FormatValidatorInterface.php
+++ b/src/Format/FormatValidatorInterface.php
@@ -11,5 +11,5 @@ interface FormatValidatorInterface
      *
      *
      */
-    public static function validate(string $input): bool;
+    public static function validate(?string $input): bool;
 }

--- a/src/Format/Ipv6FormatValidator.php
+++ b/src/Format/Ipv6FormatValidator.php
@@ -6,8 +6,12 @@ namespace PHPModelGenerator\Format;
 
 class Ipv6FormatValidator implements FormatValidatorInterface
 {
-    public static function validate(string $input): bool
+    public static function validate(?string $input): bool
     {
+        if ($input === null) {
+            return true;
+        }
+
         return filter_var($input, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false;
     }
 }

--- a/src/Format/IriFormatValidator.php
+++ b/src/Format/IriFormatValidator.php
@@ -6,8 +6,12 @@ namespace PHPModelGenerator\Format;
 
 class IriFormatValidator implements FormatValidatorInterface
 {
-    public static function validate(string $input): bool
+    public static function validate(?string $input): bool
     {
+        if ($input === null) {
+            return true;
+        }
+
         // An IRI (RFC 3987) extends URIs to allow Unicode characters.
         // Require a scheme followed by :// and a non-empty authority/path,
         // with no control characters or unencoded spaces.

--- a/src/Format/IriReferenceFormatValidator.php
+++ b/src/Format/IriReferenceFormatValidator.php
@@ -6,8 +6,12 @@ namespace PHPModelGenerator\Format;
 
 class IriReferenceFormatValidator implements FormatValidatorInterface
 {
-    public static function validate(string $input): bool
+    public static function validate(?string $input): bool
     {
+        if ($input === null) {
+            return true;
+        }
+
         // An IRI-reference is either an absolute IRI or a relative reference allowing Unicode.
         if (IriFormatValidator::validate($input)) {
             return true;

--- a/src/Format/RegexFormatValidator.php
+++ b/src/Format/RegexFormatValidator.php
@@ -6,8 +6,12 @@ namespace PHPModelGenerator\Format;
 
 class RegexFormatValidator implements FormatValidatorInterface
 {
-    public static function validate(string $input): bool
+    public static function validate(?string $input): bool
     {
+        if ($input === null) {
+            return true;
+        }
+
         return @preg_match($input, '') !== false;
     }
 }

--- a/src/Format/UriFormatValidator.php
+++ b/src/Format/UriFormatValidator.php
@@ -6,8 +6,12 @@ namespace PHPModelGenerator\Format;
 
 class UriFormatValidator implements FormatValidatorInterface
 {
-    public static function validate(string $input): bool
+    public static function validate(?string $input): bool
     {
+        if ($input === null) {
+            return true;
+        }
+
         // RFC 3986 absolute URI: must have a scheme and a non-empty authority/path
         if (!filter_var($input, FILTER_VALIDATE_URL)) {
             return false;

--- a/src/Format/UriReferenceFormatValidator.php
+++ b/src/Format/UriReferenceFormatValidator.php
@@ -6,8 +6,12 @@ namespace PHPModelGenerator\Format;
 
 class UriReferenceFormatValidator implements FormatValidatorInterface
 {
-    public static function validate(string $input): bool
+    public static function validate(?string $input): bool
     {
+        if ($input === null) {
+            return true;
+        }
+
         // Empty string is a valid URI-reference (refers to the current document)
         if ($input === '') {
             return true;

--- a/src/Format/UriTemplateFormatValidator.php
+++ b/src/Format/UriTemplateFormatValidator.php
@@ -6,8 +6,12 @@ namespace PHPModelGenerator\Format;
 
 class UriTemplateFormatValidator implements FormatValidatorInterface
 {
-    public static function validate(string $input): bool
+    public static function validate(?string $input): bool
     {
+        if ($input === null) {
+            return true;
+        }
+
         // RFC 6570 URI Template: no spaces and all braces must be properly closed
         if (preg_match('/\s/', $input)) {
             return false;

--- a/src/Traits/SerializableTrait.php
+++ b/src/Traits/SerializableTrait.php
@@ -259,7 +259,7 @@ trait SerializableTrait
     /**
      * Public wrapper for _getSerializedValue, called from generated serialization hooks.
      */
-    protected function getSerializedValue($value, int $depth, array $except): array
+    protected function getSerializedValue($value, int $depth, array $except)
     {
         return $this->_getSerializedValue($value, $depth, $except);
     }

--- a/src/Traits/SerializableTrait.php
+++ b/src/Traits/SerializableTrait.php
@@ -256,6 +256,22 @@ trait SerializableTrait
         return $serializedPatternProperties;
     }
 
+    /**
+     * Public wrapper for _getSerializedValue, called from generated serialization hooks.
+     */
+    protected function getSerializedValue($value, int $depth, array $except): array
+    {
+        return $this->_getSerializedValue($value, $depth, $except);
+    }
+
+    /**
+     * Public wrapper for _getCustomSerializerMethod, called from generated serialization hooks.
+     */
+    protected function getCustomSerializerMethod(string $property)
+    {
+        return $this->_getCustomSerializerMethod($property);
+    }
+
     private function _getSerializedValue($value, int $depth, array $except, bool $emptyObjectsAsStdClass = false)
     {
         if (is_array($value)) {


### PR DESCRIPTION
## Summary

Three fixes for the production runtime library, rebased on upstream master:

1. **Format validators null-safety**: Guard format validation with `?string` input to prevent null values from reaching validators. Affects FormatValidatorInterface, FormatValidatorFromRegEx, Ipv6, Iri, IriReference, Regex, Uri, UriReference, UriTemplate validators.

2. **Composition exception messages**: Improve exception messages with branch descriptions, discriminator support, and structured error output for better debugging of composed model validation errors. Includes formatProvidedValue fix that shows object class name instead of leaking internal state via get_object_vars().

3. **SerializableTrait**: Add public getSerializedValue() and getCustomSerializerMethod() wrappers for the private methods, needed by generated model serialization hooks.